### PR TITLE
toska hijack

### DIFF
--- a/.github/workflows/build_production.yml
+++ b/.github/workflows/build_production.yml
@@ -1,40 +1,30 @@
 name: Build and push docker image (production)
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
-  build-and-push:
+  build-and-store:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Build frontend
+      - name: Build frontend
         run: |
           npm --prefix ./frontend ci
           npm --prefix ./frontend run build
-      -
-        name: Build backend
+      - name: Build backend
         run: |
           npm --prefix ./backend ci
           npm --prefix ./backend run build
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Build and and export
+        uses: redhat-actions/push-to-registry@v2
         with:
           context: .
-          push: true
-          tags: arttkan/finlex-lukija:production
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/toska
+          username: toska+github
+          password: ${{ secrets.QUAY_IO_TOKEN }}
+   


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing the production Docker image. The workflow is now triggered by a published release instead of a push to the `main` branch, and it replaces Docker Hub with Quay.io as the image registry. The Docker build and push steps have also been simplified using a different GitHub Action.

Workflow trigger and registry updates:

* Changed workflow trigger from `push` on the `main` branch to `release` events of type `published`, ensuring production images are built only for official releases.
* Replaced Docker Hub authentication and image publishing with Quay.io, updating credentials and registry settings for the new destination.

Build and deployment process changes:

* Consolidated Docker build and push steps using `redhat-actions/push-to-registry@v2`, simplifying the workflow and removing separate setup steps for Docker Buildx and Docker login.